### PR TITLE
Move to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM alpine:latest
 
 MAINTAINER Eliot Lear "lear@lear.ch"
 
@@ -6,11 +6,13 @@ COPY ./requirements.txt /app/requirements.txt
 
 WORKDIR /app
 
-RUN pip3 install -r requirements.txt
+RUN apk add python3 uwsgi-cgi py3-cryptography py3-pip py3-werkzeug \
+    	    py3-flask py3-authlib uwsgi-http uwsgi uwsgi-python3 tzdata && \
+    pip3 install -r requirements.txt
 
 COPY . /app
 
 ENTRYPOINT [ "uwsgi" ]
 
-CMD ["uwsgi.ini"]
+CMD ["--http-socket",":5000","--plugin","python","uwsgi.ini"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,4 @@
 Authlib==0.14.3
-cffi==1.15.0
-click==8.0.3
-Flask==2.0.2
 Flask-Auth==0.85
 Flask-HTTPAuth==4.5.0
-Flask-SQLAlchemy==2.5.1
-greenlet==1.1.2
-itsdangerous==2.0.1
-Jinja2==3.0.3
-MarkupSafe==2.0.1
 passwordgenerator==1.4
-pycparser==2.21
-SQLAlchemy==1.4.28
-uWSGI==2.0.20
-Werkzeug==2.0.2


### PR DESCRIPTION
Alpine is a stripped down linux with a stripped down package manager.  To use it effectively, we need for python's cryptography and uwsgi packages to be up to 3.9.  They are.  By using apk we are avoiding a whole source build.  The result is an image size reduction of over 90%.