### PR TITLE
ignore iocccpasswd, move port from tcp/5000 to tcp/8191

### DIFF
--- a/.gitigore
+++ b/.gitigore
@@ -1,0 +1,2 @@
+# We sort the list below via: sort -d -u
+iocccpasswd

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ COPY . /app
 
 ENTRYPOINT [ "uwsgi" ]
 
-CMD ["--http-socket",":5000","--plugin","python","uwsgi.ini"]
+CMD ["--http-socket",":8191","--plugin","python","uwsgi.ini"]
 

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,5 +1,5 @@
 [uwsgi]
-http=:5000
+http=:8191
 wsgi-file = ioccc.py
 callable = application
 processes = 1


### PR DESCRIPTION
Added iocccpasswd to `.gitignore` to prevent it from being uploaded to the repo.

Changed TCP port from tcp/5000 to tcp/8191 to avoid a case where tcp/5000 was in use on one of our test systems.